### PR TITLE
fix: Fix error handling on tracking operations [DEV-3527]

### DIFF
--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -95,41 +95,28 @@ export class AccountController {
 		}
 
 		const identityStrategySetup = new IdentityServiceStrategySetup(response.locals.customer.customerId);
-		let apiKey = await identityStrategySetup.agent.getAPIKey(response.locals.customer, response.locals.user);
-		// If there is no API key for the customer - create it
-		if (!apiKey) {
-			apiKey = await identityStrategySetup.agent.setAPIKey(
-				request.session.idToken,
-				response.locals.customer,
-				response.locals.user
-			);
-		} else if (apiKey.isExpired()) {
-			// If API key is expired - update it
-			apiKey = await identityStrategySetup.agent.updateAPIKey(apiKey, request.session.idToken);
-		}
-		return response.status(StatusCodes.OK).json({
-			idToken: apiKey?.apiKey,
-		});
-	}
-
-	public async setupDefaultRole(request: Request, response: Response) {
-		if (request.body) {
-			const { body } = request;
-			if (!body.user.isSuspended) {
-				const logToHelper = new LogToHelper();
-				const _r = await logToHelper.setup();
-				if (_r.status !== StatusCodes.OK) {
-					return response.status(StatusCodes.BAD_GATEWAY).json({
-						error: _r.error,
-					});
-				}
-				const resp = await logToHelper.setDefaultRoleForUser(body.user.id as string);
-				return response.status(resp.status).json({
-					error: resp.error,
-				});
+		try {
+			// Get the API key for the customer
+			let apiKey = await identityStrategySetup.agent.getAPIKey(response.locals.customer, response.locals.user);
+			// If there is no API key for the customer - create it
+			if (!apiKey) {
+				apiKey = await identityStrategySetup.agent.setAPIKey(
+					request.session.idToken,
+					response.locals.customer,
+					response.locals.user
+				);
+			} else if (apiKey.isExpired()) {
+				// If API key is expired - update it
+				apiKey = await identityStrategySetup.agent.updateAPIKey(apiKey, request.session.idToken);
 			}
+			return response.status(StatusCodes.OK).json({
+				idToken: apiKey?.apiKey,
+			});
+		} catch (error) {
+			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+				error: `Internal error: ${(error as Error)?.message || error}`,
+			});
 		}
-		return response.status(StatusCodes.BAD_REQUEST).json({});
 	}
 
 	public async bootstrap(request: Request, response: Response) {

--- a/src/controllers/credential-status.ts
+++ b/src/controllers/credential-status.ts
@@ -3,19 +3,18 @@ import { check, validationResult, query } from './validator/index.js';
 import { fromString } from 'uint8arrays';
 import { StatusCodes } from 'http-status-codes';
 import { IdentityServiceStrategySetup } from '../services/identity/index.js';
-import type {
-	ITrackOperation,
-} from '../types/shared.js';
+import type { ITrackOperation } from '../types/shared.js';
 import type { CheckStatusListSuccessfulResponseBody, FeePaymentOptions } from '../types/credential-status.js';
 import {
 	DefaultStatusAction,
 	DefaultStatusActionPurposeMap,
-	DefaultStatusActions, MinimalPaymentCondition
+	DefaultStatusActions,
+	MinimalPaymentCondition,
 } from '../types/credential-status.js';
 import type {
 	SearchStatusListQuery,
 	SearchStatusListSuccessfulResponseBody,
-	SearchStatusListUnsuccessfulResponseBody
+	SearchStatusListUnsuccessfulResponseBody,
 } from '../types/credential-status.js';
 import type {
 	CheckStatusListRequestBody,
@@ -28,13 +27,14 @@ import type {
 	CreateUnencryptedStatusListRequestBody,
 	CreateUnencryptedStatusListRequestQuery,
 	CreateUnencryptedStatusListSuccessfulResponseBody,
-	CreateUnencryptedStatusListUnsuccessfulResponseBody, UpdateEncryptedStatusListRequestBody,
+	CreateUnencryptedStatusListUnsuccessfulResponseBody,
+	UpdateEncryptedStatusListRequestBody,
 	UpdateEncryptedStatusListSuccessfulResponseBody,
 	UpdateEncryptedStatusListUnsuccessfulResponseBody,
 	UpdateUnencryptedStatusListRequestBody,
 	UpdateUnencryptedStatusListRequestQuery,
 	UpdateUnencryptedStatusListSuccessfulResponseBody,
-	UpdateUnencryptedStatusListUnsuccessfulResponseBody
+	UpdateUnencryptedStatusListUnsuccessfulResponseBody,
 } from '../types/credential-status.js';
 import {
 	BulkRevocationResult,
@@ -562,15 +562,9 @@ export class CredentialStatusController {
 				},
 			} as ITrackOperation;
 
-			const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
-			if (trackResult.error) {
-				return response
-					.status(StatusCodes.INTERNAL_SERVER_ERROR)
-					.json(trackResult as CreateEncryptedStatusListUnsuccessfulResponseBody);
-			}
-
+			const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
 			// return result
-			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined });
+			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined, trackingStatus });
 		} catch (error) {
 			// return catch-all error
 			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -695,16 +689,9 @@ export class CredentialStatusController {
 					feePaymentNetwork: CheqdNetwork.Testnet,
 				},
 			} as ITrackOperation;
-			const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
-
-			if (trackResult.error) {
-				return response
-					.status(StatusCodes.INTERNAL_SERVER_ERROR)
-					.json(trackResult as CreateEncryptedStatusListUnsuccessfulResponseBody);
-			}
-
+			const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
 			// return result
-			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined });
+			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined, trackingStatus });
 		} catch (error) {
 			// return catch-all error
 			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -873,13 +860,11 @@ export class CredentialStatusController {
 						symmetricKey: '',
 					},
 				} as ITrackOperation;
-				const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
-				if (trackResult.error) {
-					return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-						updated: false,
-						error: trackResult.error,
-					} as UpdateUnencryptedStatusListUnsuccessfulResponseBody);
-				}
+				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
+				return response.status(StatusCodes.OK).json({
+					...formatted,
+					trackingStatus,
+				});
 			}
 
 			return response.status(StatusCodes.OK).json(formatted);
@@ -1072,13 +1057,8 @@ export class CredentialStatusController {
 						feePaymentNetwork: CheqdNetwork.Testnet,
 					},
 				} as ITrackOperation;
-				const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
-				if (trackResult.error) {
-					return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-						updated: false,
-						error: trackResult.error,
-					} as UpdateUnencryptedStatusListUnsuccessfulResponseBody);
-				}
+				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
+				return response.status(StatusCodes.OK).json({ ...formatted, trackingStatus });
 			}
 
 			return response.status(StatusCodes.OK).json(formatted);

--- a/src/controllers/credential-status.ts
+++ b/src/controllers/credential-status.ts
@@ -562,9 +562,16 @@ export class CredentialStatusController {
 				},
 			} as ITrackOperation;
 
-			const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
+			const trackResult = await identityServiceStrategySetup.agent
+				.trackOperation(trackResourceInfo)
+				.catch((error) => {
+					return { error };
+				});
+			if (trackResult.error) {
+				console.error(`Tracking Error: ${trackResult.error}`);
+			}
 			// return result
-			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined, trackingStatus });
+			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined });
 		} catch (error) {
 			// return catch-all error
 			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -689,9 +696,16 @@ export class CredentialStatusController {
 					feePaymentNetwork: CheqdNetwork.Testnet,
 				},
 			} as ITrackOperation;
-			const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
+			const trackResult = await identityServiceStrategySetup.agent
+				.trackOperation(trackResourceInfo)
+				.catch((error) => {
+					return { error };
+				});
+			if (trackResult.error) {
+				console.error(`Tracking Error: ${trackResult.error}`);
+			}
 			// return result
-			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined, trackingStatus });
+			return response.status(StatusCodes.OK).json({ ...result, encrypted: undefined });
 		} catch (error) {
 			// return catch-all error
 			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -860,10 +874,16 @@ export class CredentialStatusController {
 						symmetricKey: '',
 					},
 				} as ITrackOperation;
-				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
+				const trackResult = await identityServiceStrategySetup.agent
+					.trackOperation(trackResourceInfo)
+					.catch((error) => {
+						return { error };
+					});
+				if (trackResult.error) {
+					console.error(`Tracking Error: ${trackResult.error}`);
+				}
 				return response.status(StatusCodes.OK).json({
 					...formatted,
-					trackingStatus,
 				});
 			}
 
@@ -1057,8 +1077,15 @@ export class CredentialStatusController {
 						feePaymentNetwork: CheqdNetwork.Testnet,
 					},
 				} as ITrackOperation;
-				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
-				return response.status(StatusCodes.OK).json({ ...formatted, trackingStatus });
+				const trackResult = await identityServiceStrategySetup.agent
+					.trackOperation(trackResourceInfo)
+					.catch((error) => {
+						return { error };
+					});
+				if (trackResult.error) {
+					console.error(`Tracking Error: ${trackResult.error}`);
+				}
+				return response.status(StatusCodes.OK).json({ ...formatted });
 			}
 
 			return response.status(StatusCodes.OK).json(formatted);

--- a/src/controllers/credential-status.ts
+++ b/src/controllers/credential-status.ts
@@ -882,9 +882,6 @@ export class CredentialStatusController {
 				if (trackResult.error) {
 					console.error(`Tracking Error: ${trackResult.error}`);
 				}
-				return response.status(StatusCodes.OK).json({
-					...formatted,
-				});
 			}
 
 			return response.status(StatusCodes.OK).json(formatted);
@@ -1085,7 +1082,6 @@ export class CredentialStatusController {
 				if (trackResult.error) {
 					console.error(`Tracking Error: ${trackResult.error}`);
 				}
-				return response.status(StatusCodes.OK).json({ ...formatted });
 			}
 
 			return response.status(StatusCodes.OK).json(formatted);

--- a/src/controllers/credentials.ts
+++ b/src/controllers/credentials.ts
@@ -331,12 +331,11 @@ export class CredentialController {
 				} as ITrackOperation;
 
 				// Track operation
-				const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
-				if (trackResult.error) {
-					return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-						error: trackResult.error,
-					});
-				}
+				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
+				return response.status(StatusCodes.OK).json({
+					...result,
+					trackingStatus,
+				});
 			}
 			// Return Ok response
 			return response.status(StatusCodes.OK).json(result);
@@ -435,12 +434,8 @@ export class CredentialController {
 				} as ITrackOperation;
 
 				// Track operation
-				const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
-				if (trackResult.error) {
-					return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-						error: trackResult.error,
-					});
-				}
+				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
+				return response.status(StatusCodes.OK).json({ ...result, trackingStatus });
 			}
 
 			return response.status(StatusCodes.OK).json(result);
@@ -537,12 +532,8 @@ export class CredentialController {
 				} as ITrackOperation;
 
 				// Track operation
-				const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
-				if (trackResult.error) {
-					return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-						error: trackResult.error,
-					});
-				}
+				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
+				return response.status(StatusCodes.OK).json({ ...result, trackingStatus });
 			}
 			// Return Ok response
 			return response.status(StatusCodes.OK).json(result);

--- a/src/controllers/credentials.ts
+++ b/src/controllers/credentials.ts
@@ -331,11 +331,15 @@ export class CredentialController {
 				} as ITrackOperation;
 
 				// Track operation
-				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
-				return response.status(StatusCodes.OK).json({
-					...result,
-					trackingStatus,
-				});
+				const trackResult = await identityServiceStrategySetup.agent
+					.trackOperation(trackInfo)
+					.catch((error) => {
+						return { error };
+					});
+				if (trackResult.error) {
+					console.error(`Tracking Error: ${trackResult.error}`);
+				}
+				return response.status(StatusCodes.OK).json(result);
 			}
 			// Return Ok response
 			return response.status(StatusCodes.OK).json(result);
@@ -434,8 +438,15 @@ export class CredentialController {
 				} as ITrackOperation;
 
 				// Track operation
-				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
-				return response.status(StatusCodes.OK).json({ ...result, trackingStatus });
+				const trackResult = await identityServiceStrategySetup.agent
+					.trackOperation(trackInfo)
+					.catch((error) => {
+						return { error };
+					});
+				if (trackResult.error) {
+					console.error(`Tracking Error: ${trackResult.error}`);
+				}
+				return response.status(StatusCodes.OK).json(result);
 			}
 
 			return response.status(StatusCodes.OK).json(result);
@@ -532,8 +543,15 @@ export class CredentialController {
 				} as ITrackOperation;
 
 				// Track operation
-				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackInfo);
-				return response.status(StatusCodes.OK).json({ ...result, trackingStatus });
+				const trackResult = await identityServiceStrategySetup.agent
+					.trackOperation(trackInfo)
+					.catch((error) => {
+						return { error };
+					});
+				if (trackResult.error) {
+					console.error(`Tracking Error: ${trackResult.error}`);
+				}
+				return response.status(StatusCodes.OK).json(result);
 			}
 			// Return Ok response
 			return response.status(StatusCodes.OK).json(result);

--- a/src/controllers/credentials.ts
+++ b/src/controllers/credentials.ts
@@ -339,7 +339,6 @@ export class CredentialController {
 				if (trackResult.error) {
 					console.error(`Tracking Error: ${trackResult.error}`);
 				}
-				return response.status(StatusCodes.OK).json(result);
 			}
 			// Return Ok response
 			return response.status(StatusCodes.OK).json(result);
@@ -446,7 +445,6 @@ export class CredentialController {
 				if (trackResult.error) {
 					console.error(`Tracking Error: ${trackResult.error}`);
 				}
-				return response.status(StatusCodes.OK).json(result);
 			}
 
 			return response.status(StatusCodes.OK).json(result);
@@ -551,7 +549,6 @@ export class CredentialController {
 				if (trackResult.error) {
 					console.error(`Tracking Error: ${trackResult.error}`);
 				}
-				return response.status(StatusCodes.OK).json(result);
 			}
 			// Return Ok response
 			return response.status(StatusCodes.OK).json(result);

--- a/src/controllers/resource.ts
+++ b/src/controllers/resource.ts
@@ -190,15 +190,11 @@ export class ResourceController {
 					},
 				} as ITrackOperation;
 
-				const trackResult = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
-				if (trackResult.error) {
-					return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-						error: `${trackResult.error}`,
-					});
-				}
+				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
 
 				return response.status(StatusCodes.CREATED).json({
 					resource,
+					trackingStatus,
 				});
 			} else {
 				return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({

--- a/src/controllers/resource.ts
+++ b/src/controllers/resource.ts
@@ -190,11 +190,17 @@ export class ResourceController {
 					},
 				} as ITrackOperation;
 
-				const trackingStatus = await identityServiceStrategySetup.agent.trackOperation(trackResourceInfo);
+				const trackResult = await identityServiceStrategySetup.agent
+					.trackOperation(trackResourceInfo)
+					.catch((error) => {
+						return { error };
+					});
+				if (trackResult.error) {
+					console.error(`Tracking Error: ${trackResult.error}`);
+				}
 
 				return response.status(StatusCodes.CREATED).json({
 					resource,
-					trackingStatus,
 				});
 			} else {
 				return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({


### PR DESCRIPTION
The earlier approach used to throw an INTERNAL ERROR if a tracking operations fails even if the api request was successfull. 

The errors are just logged silently for now.