### PR TITLE
fix: subscription update request body schema

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
                       type=sha,format=long
 
             - name: Build image
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                   context: .
                   file: docker/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
                       org.opencontainers.image.documentation="https://docs.cheqd.io/identity"
 
             - name: Build image with labels
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                   context: .
                   file: docker/Dockerfile

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cheqd/credential-service",
-	"version": "2.20.3-develop.1",
+	"version": "2.20.3-develop.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cheqd/credential-service",
-			"version": "2.20.3-develop.1",
+			"version": "2.20.3-develop.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cheqd/did-provider-cheqd": "^4.1.1",
@@ -80,7 +80,7 @@
 				"@types/helmet": "^4.0.0",
 				"@types/json-stringify-safe": "^5.0.3",
 				"@types/jsonwebtoken": "^9.0.6",
-				"@types/node": "^20.14.7",
+				"@types/node": "^20.14.8",
 				"@types/secp256k1": "^4.0.6",
 				"@types/swagger-jsdoc": "^6.0.4",
 				"@types/swagger-ui-express": "^4.1.6",
@@ -5157,9 +5157,9 @@
 			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
 		},
 		"node_modules/@ipld/dag-pb": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.1.tgz",
-			"integrity": "sha512-wsSNjIvcABXuH9MKXpvRGMXsS20+Kf2Q0Hq2+2dxN6Wpw/K0kDF3nDmCnO6wlpninQ0vzx1zq54O3ttn5pTH9A==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.2.tgz",
+			"integrity": "sha512-BSztO4l3C+ya9HjCaQot26Y4AVsqIKtnn6+23ubc1usucnf6yoTBme18oCCdM6gKBMxuPqju5ye3lh9WEJsdeQ==",
 			"dependencies": {
 				"multiformats": "^13.1.0"
 			},
@@ -10173,9 +10173,9 @@
 			}
 		},
 		"node_modules/@rnx-kit/chromium-edge-launcher/node_modules/@types/node": {
-			"version": "18.19.38",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.38.tgz",
-			"integrity": "sha512-SApYXUF7si4JJ+lO2o6X60OPOnA6wPpbiB09GMCkQ+JAwpa9hxUVG8p7GzA08TKQn5OhzK57rj1wFj+185YsGg==",
+			"version": "18.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
+			"integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
 			"optional": true,
 			"peer": true,
 			"dependencies": {
@@ -11540,9 +11540,9 @@
 			"integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
-			"integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
+			"version": "20.14.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+			"integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -12857,9 +12857,9 @@
 			}
 		},
 		"node_modules/@verida/types/node_modules/@types/node": {
-			"version": "18.19.38",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.38.tgz",
-			"integrity": "sha512-SApYXUF7si4JJ+lO2o6X60OPOnA6wPpbiB09GMCkQ+JAwpa9hxUVG8p7GzA08TKQn5OhzK57rj1wFj+185YsGg==",
+			"version": "18.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
+			"integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -16994,9 +16994,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.808",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.808.tgz",
-			"integrity": "sha512-0ItWyhPYnww2VOuCGF4s1LTfbrdAV2ajy/TN+ZTuhR23AHI6rWHCrBXJ/uxoXOvRRqw8qjYVrG81HFI7x/2wdQ=="
+			"version": "1.4.810",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.810.tgz",
+			"integrity": "sha512-Kaxhu4T7SJGpRQx99tq216gCq2nMxJo+uuT6uzz9l8TVN2stL7M06MIIXAtr9jsrLs2Glflgf2vMQRepxawOdQ=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.5",
@@ -17442,9 +17442,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-			"integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
 			"dev": true,
 			"peer": true
 		},
@@ -27701,9 +27701,12 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -30923,9 +30926,9 @@
 			}
 		},
 		"node_modules/semantic-release/node_modules/execa": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
-			"integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.3.0.tgz",
+			"integrity": "sha512-l6JFbqnHEadBoVAVpN5dl2yCyfX28WoBAGaoQcNmLLSedOxTxcn2Qa83s8I/PA5i56vWru2OHOtrwF7Om2vqlg==",
 			"dev": true,
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^4.0.0",
@@ -34063,9 +34066,9 @@
 			"devOptional": true
 		},
 		"node_modules/v8-to-istanbul": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-			"integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.12",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"@types/helmet": "^4.0.0",
 		"@types/json-stringify-safe": "^5.0.3",
 		"@types/jsonwebtoken": "^9.0.6",
-		"@types/node": "^20.14.7",
+		"@types/node": "^20.14.8",
 		"@types/secp256k1": "^4.0.6",
 		"@types/swagger-jsdoc": "^6.0.4",
 		"@types/swagger-ui-express": "^4.1.6",

--- a/src/controllers/admin/subscriptions.ts
+++ b/src/controllers/admin/subscriptions.ts
@@ -257,7 +257,7 @@ export class SubscriptionController {
 	@syncOne
 	async update(request: Request, response: Response) {
 		const stripe = response.locals.stripe as Stripe;
-		const { returnUrl, isManagePlan, priceId } = request.body satisfies SubscriptionUpdateRequestBody;
+		const { returnURL, isManagePlan, priceId } = request.body satisfies SubscriptionUpdateRequestBody;
 		try {
 			// Get the subscription object from the DB
 			const subscription = await SubscriptionService.instance.findOne({ customer: response.locals.customer });
@@ -277,7 +277,7 @@ export class SubscriptionController {
 			// Create portal link
 			const session = await stripe.billingPortal.sessions.create({
 				customer: response.locals.customer.paymentProviderId,
-				return_url: returnUrl,
+				return_url: returnURL,
 				// based on request body, trigger a manage or confirm update flow.
 				flow_data: isManagePlan
 					? undefined
@@ -295,7 +295,7 @@ export class SubscriptionController {
 							after_completion: {
 								type: 'redirect',
 								redirect: {
-									return_url: returnUrl,
+									return_url: returnURL,
 								},
 							},
 						},

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -48,7 +48,7 @@ export type SubscriptionUpdateResponseBody = {
 
 // Update
 export type SubscriptionUpdateRequestBody = {
-	returnUrl: string;
+	returnURL: string;
 	isManagePlan: boolean;
 	priceId?: string;
 };


### PR DESCRIPTION
This PR's change might seem insignificant, but it actually has an impact. We have a request body validation check at the update subscritpion, that we're performing [here](https://github.com/cheqd/credential-service/blob/745308148aae1bf99b3477b61964416ad82ef5a1/src/controllers/admin/subscriptions.ts#L115). You might wonder why we don't just change the request body validation check to `returnUrl` instead. While I could do that, I chose to keep things consistent with (`successURL`, `cancelURL`). And this is why the FE is throwing an error when trying to update a plan.